### PR TITLE
Adds parameters for server_group_id

### DIFF
--- a/providers/openstack/scs/1-27/cluster-class/templates/openstack-machine-template-control-plane.yaml
+++ b/providers/openstack/scs/1-27/cluster-class/templates/openstack-machine-template-control-plane.yaml
@@ -22,5 +22,7 @@ spec:
         - name: {{ .Values.prefix }}-allow-icmp
         - name: {{ .Values.prefix }}-{{ .Values.testcluster_name }}-cilium
 {{- end}}
-      # serverGroupID left blank for now
+{{- if .Values.server_group_id_controller }}
+      serverGroupID: {{ .Values.server_group_id_controller }}
+{{- end}}
       sshKeyName: {{ .Values.prefix }}-keypair

--- a/providers/openstack/scs/1-27/cluster-class/templates/openstack-machine-template-worker.yaml
+++ b/providers/openstack/scs/1-27/cluster-class/templates/openstack-machine-template-worker.yaml
@@ -22,6 +22,8 @@ spec:
         - name: {{ .Values.prefix }}-allow-icmp
         - name: {{ .Values.prefix }}-{{ .Values.testcluster_name }}-cilium
 {{- end}}
-      # serverGroupID left blank for now
+{{- if .Values.server_group_id_worker }}
+      serverGroupID: {{ .Values.server_group_id_worker }}
+{{- end}}
       sshKeyName: {{ .Values.prefix }}-keypair
 

--- a/providers/openstack/scs/1-27/cluster-class/values.yaml
+++ b/providers/openstack/scs/1-27/cluster-class/values.yaml
@@ -21,6 +21,8 @@ tweak_kubeapi_memlimit: true
 worker_machine_gen: genw01
 control_plane_machine_gen: genc01
 openstack_security_groups: []
+server_group_id_controller: ""
+server_group_id_worker: ""
 
 # TBD, currently needed:
 images:


### PR DESCRIPTION
One parameter for the worker nodes and one for the controller nodes. With this parameter. All values that have been used in k8s-cluster-api-provider can now be set via helm.