### PR TITLE
Adds new helper chart

### DIFF
--- a/providers/openstack/alpha/1-28/csp-helper-chart/.helmignore
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/providers/openstack/alpha/1-28/csp-helper-chart/Chart.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: csp-helper-chart
+description: A Helm chart to deploy SCS cluster-api-provider-v2 per-tenant resources
+version: 0.1.0
+appVersion: "0.1.0"

--- a/providers/openstack/alpha/1-28/csp-helper-chart/README.md
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/README.md
@@ -1,0 +1,1 @@
+This chart can be used to create a new namespace and two secrets for the clusterstacks approach. It reads clouds.yaml files in its raw form either with username and password or with an application credential. In case of an application credential, a new namespace is created named after the application-credential-id.

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/NOTES.txt
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/NOTES.txt
@@ -1,0 +1,39 @@
+Created namespace {{ include "namespaceName" . }}.
+
+You can create a new cluster like this:
+cat <<EOF | kubectl apply -f -
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: cs-cluster
+  namespace: {{ include "namespaceName" . }}
+  labels:
+    managed-secret: cloud-config
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+        - 10.96.0.0/12
+  topology:
+    variables:
+      - name: controller_flavor
+        value: "SCS-2V-4-50"
+      - name: worker_flavor
+        value: "SCS-2V-4-50"
+      - name: external_id
+        value: "ebfe5546-f09f-4f42-ab54-094e457d42ec" # gx-scs
+    class: openstack-alpha-1-28-v3
+    controlPlane:
+      replicas: 1
+    version: v1.28.6
+    workers:
+      machineDeployments:
+        - class: capi-openstack-alpha-1-28
+          failureDomain: nova
+          name: capi-openstack-alpha-1-28
+          replicas: 3
+EOF

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/_helpers.tpl
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{/*
+Templates the cloud.conf as needed by the openstack CCM
+*/}}
+{{- define "cloud.conf" -}}
+[Global]
+auth-url={{ .Values.clouds.openstack.auth.auth_url }}
+region={{ .Values.clouds.openstack.region_name }}
+username={{ .Values.clouds.openstack.auth.username }}
+password={{ .Values.clouds.openstack.auth.password }}
+user-domain-name={{ .Values.clouds.openstack.auth.user_domain_name }}
+tenant-id={{ .Values.clouds.openstack.auth.project_id }}
+
+[LoadBalancer]
+manage-security-groups=true
+use-octavia=true
+enable-ingress-hostname=true
+create-monitor=true
+{{- end }}
+
+
+
+{{/*
+Templates the secret that contains cloud.conf as needed by the openstack CCM
+*/}}
+
+{{- define "cloud-config" -}}
+apiVersion: v1
+data:
+  cloud.conf: {{ include "cloud.conf" . | b64enc }}
+kind: Secret
+metadata:
+  name: cloud-config
+  namespace: kube-system
+type: Opaque
+{{- end }}

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/_helpers.tpl
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/_helpers.tpl
@@ -1,14 +1,45 @@
 {{/*
+Checks whether we have a regular clouds.yaml or one with application credentials.
+*/}}
+{{- define "isAppCredential" -}}
+{{- if and .Values.clouds.openstack.auth.username (not .Values.clouds.openstack.auth.application_credential_id) -}}
+{{- else if and (not .Values.clouds.openstack.auth.username) .Values.clouds.openstack.auth.application_credential_id -}}
+true
+{{- else }}
+{{ fail "please provide either username or application_credential_id, not both, not none" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creates name of the namespace: appcredxxx in case of an application credential, project_name otherwise
+*/}}
+{{- define "namespaceName" -}}
+{{- if include "isAppCredential" . -}}
+appcred-{{ substr 0 10 .Values.clouds.openstack.auth.application_credential_id }}
+{{- else -}}
+{{ .Values.clouds.openstack.auth.project_name }}
+{{ end }}
+{{- end }}
+
+
+
+
+{{/*
 Templates the cloud.conf as needed by the openstack CCM
 */}}
 {{- define "cloud.conf" -}}
 [Global]
 auth-url={{ .Values.clouds.openstack.auth.auth_url }}
 region={{ .Values.clouds.openstack.region_name }}
+{{ if include "isAppCredential" . }}
+application-credential-id={{ .Values.clouds.openstack.auth.application_credential_id }}
+application-credential-secret={{ .Values.clouds.openstack.auth.application_credential_secret }}
+{{- else -}}
 username={{ .Values.clouds.openstack.auth.username }}
 password={{ .Values.clouds.openstack.auth.password }}
 user-domain-name={{ .Values.clouds.openstack.auth.user_domain_name }}
 tenant-id={{ .Values.clouds.openstack.auth.project_id }}
+{{ end }}
 
 [LoadBalancer]
 manage-security-groups=true
@@ -22,7 +53,6 @@ create-monitor=true
 {{/*
 Templates the secret that contains cloud.conf as needed by the openstack CCM
 */}}
-
 {{- define "cloud-config" -}}
 apiVersion: v1
 data:

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/cloud-secret.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/cloud-secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-data:
-  clouds.yaml: {{ toYaml .Values | b64enc }}
 kind: Secret
 metadata:
   name: openstack
-  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+  namespace: {{ include "namespaceName" . }}
+data:
+  clouds.yaml: {{ toYaml .Values | b64enc }}
 type: Opaque

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/cloud-secret.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/cloud-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  clouds.yaml: {{ toYaml .Values | b64enc }}
+kind: Secret
+metadata:
+  name: openstack
+  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+type: Opaque

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/cluster-resource-set.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/cluster-resource-set.yaml
@@ -1,0 +1,13 @@
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: crs-openstack-secret
+  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+spec:
+  strategy: "Reconcile"
+  clusterSelector:
+    matchLabels:
+      managed-secret: cloud-config
+  resources:
+    - name: openstack-workload-cluster-secret
+      kind: Secret

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/cluster-resource-set.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/cluster-resource-set.yaml
@@ -2,7 +2,7 @@ apiVersion: addons.cluster.x-k8s.io/v1beta1
 kind: ClusterResourceSet
 metadata:
   name: crs-openstack-secret
-  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+  namespace: {{ include "namespaceName" . }}
 spec:
   strategy: "Reconcile"
   clusterSelector:

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/namespace.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.clouds.openstack.auth.project_name }}
+  name: {{ include "namespaceName" . }}

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/namespace.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.clouds.openstack.auth.project_name }}

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/openstack-workload-cluster-secret.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/openstack-workload-cluster-secret.yaml
@@ -4,5 +4,5 @@ data:
 kind: Secret
 metadata:
   name: openstack-workload-cluster-secret
-  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+  namespace: {{ include "namespaceName" . }}
 type: addons.cluster.x-k8s.io/resource-set 

--- a/providers/openstack/alpha/1-28/csp-helper-chart/templates/openstack-workload-cluster-secret.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/templates/openstack-workload-cluster-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  cloud-config-secret: {{ include "cloud-config" . | b64enc }}
+kind: Secret
+metadata:
+  name: openstack-workload-cluster-secret
+  namespace: {{ .Values.clouds.openstack.auth.project_name }}
+type: addons.cluster.x-k8s.io/resource-set 

--- a/providers/openstack/alpha/1-28/csp-helper-chart/values.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/values.yaml
@@ -1,0 +1,20 @@
+# This is a clouds.yaml file, which can be used by OpenStack tools as a source
+# of configuration on how to connect to a cloud. If this is your only cloud,
+# just put this file in ~/.config/openstack/clouds.yaml and tools like
+# python-openstackclient will just work with no further config. (You will need
+# to add your password to the auth section)
+# If you have more than one cloud account, add the cloud entry to the clouds
+# section of your existing file and you can refer to them by name with
+# OS_CLOUD=openstack or --os-cloud=openstack
+clouds:
+  openstack:
+    auth:
+      auth_url: https://demo-api.scs.cloud:5000
+      username: "u1234-test"
+      project_id: e7622c1048ac4520a2d050ae141e826b
+      project_name: "p1234-project"
+      user_domain_name: "d1234"
+      password: "test"
+    region_name: "RegionTest"
+    interface: "public"
+    identity_api_version: 3

--- a/providers/openstack/alpha/1-28/csp-helper-chart/values.yaml
+++ b/providers/openstack/alpha/1-28/csp-helper-chart/values.yaml
@@ -9,12 +9,7 @@
 clouds:
   openstack:
     auth:
-      auth_url: https://demo-api.scs.cloud:5000
-      username: "u1234-test"
-      project_id: e7622c1048ac4520a2d050ae141e826b
       project_name: "p1234-project"
-      user_domain_name: "d1234"
-      password: "test"
     region_name: "RegionTest"
     interface: "public"
     identity_api_version: 3


### PR DESCRIPTION
The chart can be used to transform a clouds.yaml in its unmodified form as retrieved from openstacks horizon ui into:

* a namespace with the same name as the openstack project
* a secret in that namespace with the contents of the clouds.yaml
* a secret containing a secret that contains the cloud.conf with credentials from the clouds.yaml in the format that is expected by OCCM
* a clusterresourceset to automatically transfer the OCCM secret to any correctly labeled workload cluster

Currently this only works with clouds.yaml with username and passwort. Application credential clouds.yaml may be added in the future

