### PR TITLE
added: script to generate markdown table

### DIFF
--- a/hack/docugen.py
+++ b/hack/docugen.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+"""
+Generate markdown table from cluster-class variable definitions.
+
+This script temporarily renders the helm template of the cluster-class.
+Parses the `Cluster.spec.topology.variables` definitions and
+generates a markdown table for documentation purposes.
+"""
+
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+BASE_PATH = Path(__file__).parent.parent
+TEMPLATE_PATH = BASE_PATH.joinpath(
+    "providers", "openstack", "scs", "1-27", "cluster-class"
+)
+
+
+def generate_row(content: list):
+    """Generate string of markdown table row."""
+    row_tmpl = "|{content}|"
+    row_str = "|".join(content)
+
+    return row_tmpl.format(content=row_str)
+
+
+def parse_variable(tmpl: dict) -> list:
+    """
+    Parse schema of simple cluster-stack variable type. (String, Boolean, Integer, Array)
+
+        Parameters:
+            tmpl (dict): Dictionary of variable schema,
+                         parsed from cluster-class.yaml via yaml.safe_load().
+
+        Returns: List of variable schema properties.
+                 Each entry represents a column in the final markdown table row.
+    """
+    var_name = tmpl["name"]
+    var_required = tmpl["required"]
+    var_schema = tmpl["schema"]["openAPIV3Schema"]
+
+    var_type = var_schema["type"]
+    var_default = var_schema.get("default", "")
+    var_example = var_schema.get("example", "")
+    var_desc = var_schema.get("description", "TODO")
+
+    row = []
+    row.append(var_name)
+    row.append(var_type)
+
+    # Make sure that example and default values are quoted in the table
+    if var_type == "string":
+        row.append(f'"{var_default}"')
+        row.append(f'"{var_example}"')
+
+    # Cast any non-string type example / default to string
+    if var_type in ["array", "integer", "boolean"]:
+        row.append(str(var_default))
+        row.append(str(var_example))
+
+    row.append(var_desc.replace("\n", "<br>"))
+    row.append(str(var_required))  # Convert boolean variable to string
+
+    return row
+
+
+def parse_object(tmpl: dict) -> list:
+    """
+    Parse cluster-stack variable schema of type object.
+    Separated due to nesting in YAML format.
+        Parameters:
+            tmpl (dict): Dictionary of object schema,
+                         parsed from cluster-class.yaml via yaml.safe_load().
+
+        Returns:
+            List of object properties.
+            Each entry represents a row in the final markdown table as a list,
+            consisting of the rows column values.
+    """
+    var_name = tmpl["name"]
+    props = tmpl["schema"]["openAPIV3Schema"]["properties"]
+
+    object_list = []
+    for prop in props:
+        row = []
+        row.append(f"{var_name}.{prop}")
+        row.append(props[prop]["type"])
+        row.append(props[prop].get("default", ""))
+        row.append(props[prop].get("example", ""))
+        row.append(props[prop].get("description", "TODO"))
+        # append dummy row for required field
+        row.append("")
+
+        object_list.append(row)
+    return object_list
+
+
+if __name__ == "__main__":
+    cmd = [
+        "helm",
+        "template",
+        "docugen",
+        TEMPLATE_PATH,
+        "-s",
+        "templates/cluster-class.yaml",
+    ]
+
+    cmdout = subprocess.run(cmd, capture_output=True, check=False)
+    rendered_template = cmdout.stdout.decode("utf-8")
+
+    template = yaml.safe_load(rendered_template)
+
+    result_table = []
+    result_table.append("|Name|Type|Default|Example|Description|Required|")
+    result_table.append("|----|----|-------|-------|-----------|--------|")
+
+    for var in template["spec"]["variables"]:
+        if var["schema"]["openAPIV3Schema"]["type"] in ["object"]:
+            parsed = parse_object(var)
+            for object_property in parsed:
+                result_table.append(generate_row(object_property))
+        else:
+            parsed = parse_variable(var)
+            result_table.append(generate_row(parsed))
+
+    print("\n".join(result_table))

--- a/hack/docugen.py
+++ b/hack/docugen.py
@@ -49,7 +49,7 @@ def parse_variable(tmpl: dict) -> list:
     var_desc = var_schema.get("description", "TODO")
 
     row = []
-    row.append(var_name)
+    row.append(f"`{var_name}`")
     row.append(var_type)
 
     # Make sure that example and default values are quoted in the table
@@ -87,7 +87,7 @@ def parse_object(tmpl: dict) -> list:
     object_list = []
     for prop in props:
         row = []
-        row.append(f"{var_name}.{prop}")
+        row.append(f"`{var_name}.{prop}`")
         row.append(props[prop]["type"])
         row.append(props[prop].get("default", ""))
         row.append(props[prop].get("example", ""))


### PR DESCRIPTION
PoC script to auto-generate markdown table from variable definitions of our cluster-class.

The script renders the `cluster-class.yaml` template using `helm template` and parses the `spec.variables` to generate a markdown table. The result is only printed to stdout currently.

The source `cluster-class.yaml` is hard-coded to `cluster-stacks/providers/openstack/scs/1-27/cluster-class/` as of right now. This needs to be adapted once the consolidation of the directory structure (#56) is done.

Usage:
To use the script, the [pyyaml library](https://github.com/yaml/pyyaml) needs to be installed.

```
# execute script 
python cluster-stacks/hack/docugen.py
```

The output can then be copied to a markdown file, redirected to a file:
```
python cluster-stacks/hack/docugen.py > <destination_file>.md
```
or piped to `xclip` for example:
```
python cluster-stacks/hack/docugen.py | xclip -selection clipboard
```

## Possible extensions
While the script does a good amount of "legwork" already, it could be further extended to feed the result to our documentation as @mxmxchere commented in [the issue](https://github.com/SovereignCloudStack/cluster-stacks/issues/72#issuecomment-2084758362). This could be implemented in a way that either:
- the script uses a "template" file for the corresponding docs page, fills the table and provides the output to manually commit to the docs repo
or:
- prepare a docs page file from a template as above and then utilize a git library to automatically create a commit

With the later being a bit more complicated but further automatic this task.

closes: #72

---

### Result example

|Name|Type|Default|Example|Description|Required|
|----|----|-------|-------|-----------|--------|
|external_id|string|"ebfe5546-f09f-4f42-ab54-094e457d42ec"|"ebfe5546-f09f-4f42-ab54-094e457d42ec"|ExternalNetworkID is the ID of an external OpenStack Network. This is necessary to get public internet to the VMs.|False|
|controller_flavor|string|"SCS-2V-4-20"|"SCS-2V-4-20"|OpenStack instance flavor for control-plane nodes.|False|
|worker_flavor|string|"SCS-2V-4-20"|"SCS-2V-4-20"|OpenStack instance flavor for worker nodes.|False|
|controller_root_disk|integer||20|Root disk size in GiB for control-plane nodes. OpenStack volume will be created and used instead of an ephemeral disk defined in flavor. Should be used also for the diskless flavors.|False|
|worker_root_disk|integer||20|Root disk size in GiB for worker nodes. OpenStack volume will be created and used instead of an ephemeral disk defined in flavor. Should be used also for the diskless flavors.|False|
|yawol_flavor_id|string|""|"0a79590e-10d7-4c2c-8f69-ca0a2c6208d2"|ID of the existing flavor used as a default yawol flavor.|False|
|yawol_image_id|string|""|"f0b2ef46-f0ff-43d2-9c08-f58a5a6e9060"|ID of the existing imaged used as a default yawol image.|False|
|kube_vip_network_id|string|""|"40a51f6c-9e4b-4b24-9187-49851a410c97"|ID of the existing network. The network should have one subnet with one port reserved as virtual IP.|False|
|kube_vip_apiserver_virtual_ip|string|""|"10.0.0.197"|Virtual IP address reserved in kube_vip_network_id.|False|
|kube_vip_apiserver_public_ip|string|""|""|Public IP address associated with kube_vip_apiserver_virtual_ip. It is needed only when the management cluster is on a different network as a workload cluster.|False|
|openstack_security_groups|array|[]|['security-group-1']|The names of the security groups to assign to the instance|False|
|cloud_name|string|"openstack"|"openstack"|The name of the cloud to use from the clouds secret|False|
|secret_name|string|"openstack"|"openstack"|The name of the clouds secret|False|
|controller_server_group_id|string|""|"3adf4e92-bb33-4e44-8ad3-afda9dfe8ec3"|The server group to assign the control plane nodes to.|False|
|worker_server_group_id|string|""|"869fe071-1e56-46a9-9166-47c9f228e297"|The server group to assign the worker nodes to.|False|
|ssh_key|string|""|"capi-keypair"|The ssh key to inject in the nodes.|False|
|apiserver_loadbalancer|string|"octavia-amphora"|"none, octavia-amphora, octavia-ovn, kube-vip"|"In this cluster-stack we have two kind of loadbalancers. Each of them has its own configuration variable. This setting here is to configure the loadbalancer that is placed in front of the apiserver.<br>To configure the loadbalancer for the workloads, see variable workload_loadbalancer.<br>You can choose from 4 options:<br><br>none:<br>  No loadbalancer solution will be deployed<br><br>octavia-amphora:<br>  (default) Uses openstack's loadbalancer service (provider:amphora)<br><br>octavia-ovn:<br>  Uses openstack's loadbalancer service (provider:ovn)<br><br>kube-vip:<br>  Uses kube-vip as loadbalancer.<br>  You have to provide the following additional variables: <br>    kube_vip_network_id<br>    kube_vip_apiserver_virtual_ip<br>    kube_vip_apiserver_public_ip <br> <br>  Requires Kubernetes version < 1.29<br>  Also the settings node_cidr and dns_nameservers will no longer have an effect.<br>|False|
|workload_loadbalancer|string|"octavia-amphora"|"none, octavia-amphora, octavia-ovn, yawol"|"This setting here is to configure the loadbalancer solution for your services inside your cluster.<br>If you want to configure the loadbalancer in front of your apiserver, see variable apiserver_loadbalancer instead.<br>You can choose from 4 options:<br><br>none:<br>  No loadbalancer solution will be deployed<br><br>octavia-amphora:<br>  (default) Uses openstack's loadbalancer service (provider:amphora)<br><br>octavia-ovn:<br>  Uses openstack's loadbalancer service (provider:ovn)<br><br>yawol:<br>  Uses yawol as loadbalancer.<br>  You have to provide the following additional variables: <br>    yawol_flavor_id<br>    yawol_image_id<br>  <br>  Also note this setting does not work with application credentials (only username/password)"<br>|False|
|dns_nameservers|array|['5.1.66.255', '185.150.99.255']|['5.1.66.255', '185.150.99.255']|"DNSNameservers is the list of nameservers for the OpenStack Subnet being created. Set this value when you need to create a new network/subnet while the access through DNS is required.<br>This setting has no effect when apiserver_loadbalancer is set to kube-vip.<br>However you can set the dns server when creating the subnet for kube-vip."<br>|False|
|node_cidr|string|"10.8.0.0/20"|"10.8.0.0/20"|"NodeCIDR is the OpenStack Subnet to be created. Cluster actuator will create a network, a subnet with NodeCIDR, and a router connected to this subnet. If you leave this empty, no network will be created.<br>This setting has no effect when apiserver_loadbalancer is set to kube-vip.<br>However you can set the node_cidr when creating the subnet for kube-vip."<br>|False|
|certSANs|array|[]|['mydomain.example']|CertSANs sets extra Subject Alternative Names for the API Server signing cert.|False|
