### PR TITLE
fix spec.kubernetesVersion must be type string

### DIFF
--- a/providers/openstack/README.md
+++ b/providers/openstack/README.md
@@ -132,7 +132,7 @@ metadata:
 spec:
   provider: openstack
   name: ${CS_NAME}
-  kubernetesVersion: ${CS_K8S_VERSION}
+  kubernetesVersion: "${CS_K8S_VERSION}"
   channel: ${CS_CHANNEL}
   autoSubscribe: false
   providerRef:


### PR DESCRIPTION
Fixes error in clusterstack manifest:
 `The ClusterStack "clusterstack" is invalid: spec.kubernetesVersion: Invalid value: "number": spec.kubernetesVersion in body must be of type string: "number"
`