### PR TITLE
fix(ci): Fix .yamllint file

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -11,3 +11,9 @@ rules:
   # (the latter is very common in k8s land)
   indentation:
     indent-sequences: whatever
+  # Remove this once all yaml files become docstart header
+  document-start: disable
+ignore:
+  # Help templates should and can NOT be checked with yamllint
+  - "**/templates/**"
+  - "providers/openstack/scs/1-27/cluster-addon-values.yaml"


### PR DESCRIPTION
Current yamllint validation fails (hmm, how was the check introduced if
it is failing). Fix this by explicitly excluding helm templated paths
from the check since it is NOT possible to check them with yamllint
(there is helm lint verification instead). In addition to that skip
`document-start` check until all files get the required header.

Signed-off-by: Artem Goncharov <artem.goncharov@gmail.com>

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
