### PR TITLE
:sparkles: Set cluster name in the OCCM

### DIFF
--- a/providers/openstack/scs/cluster-addon-values.yaml
+++ b/providers/openstack/scs/cluster-addon-values.yaml
@@ -30,6 +30,8 @@ values: |
   {{- end }}
 
   openstack-cloud-controller-manager:
+    cluster:
+      name: {{ .Cluster.metadata.name }}
     cloudConfig:
       loadBalancer:
       {{- range .Cluster.spec.topology.variables }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the cluster name in the OCCM to make the name for the ingress-nginx load balancer unique

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/SovereignCloudStack/k8s-cluster-api-provider/issues/495

Tested with the cluster name set to `cs-cluster`:
```
k describe po openstack-cloud-controller-manager-9l724 -n kube-system --kubeconfig cs-cluster.kubeconfig
Containers:
  openstack-cloud-controller-manager:    
    Environment:
      CLOUD_CONFIG:  /etc/config/cloud.conf
      CLUSTER_NAME:  cs-cluster
```

After the installation of Ingress-NGINX, the load balancer was created in the `gx-scs` with the expected name, see attached pic. 
![lb](https://github.com/SovereignCloudStack/cluster-stacks/assets/72123234/c0f9d27c-399e-4713-91e3-f761c10d333e)

