### PR TITLE
:sparkles: Manage Security Groups using OpenStackClusterTemplate

### DIFF
--- a/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
@@ -582,15 +582,6 @@ cre ate group names like oidc:engineering and oidc:infra."
             path: "/spec/template/spec/securityGroups"
             valueFrom:
               template: {{ `"[ {{ range .openstack_security_groups }} { filter: { name: {{ . }}}}, {{ end }} ]"` }}
-        - selector:
-            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-            kind: OpenStackClusterTemplate
-            matchResources:
-              infrastructureCluster: true
-          jsonPatches:
-          - op: replace
-            path: "/spec/template/spec/managedSecurityGroups/allowAllInClusterTraffic"
-            value: false
     - name: cloud_name
       description: "Sets the name of the cloud to use from the clouds secret."
       enabledIf: {{ `'{{ ne .cloud_name "" }}'` }}

--- a/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
+++ b/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
@@ -14,7 +14,37 @@ spec:
         allowedCIDRs: {{ .Values.restrict_kubeapi }}
 {{- end }}
       managedSecurityGroups:
-        allowAllInClusterTraffic: true
+        allNodesSecurityGroupRules:
+        - remoteManagedGroups:
+          - controlplane
+          - worker
+          direction: ingress
+          etherType: IPv4
+          name: VXLAN (Cilium)
+          portRangeMin: 8472
+          portRangeMax: 8472
+          protocol: udp
+          description: "Allow VXLAN traffic for Cilium"
+        - remoteManagedGroups:
+          - controlplane
+          - worker
+          direction: ingress
+          etherType: IPv4
+          name: HealthCheck (Cilium)
+          portRangeMin: 4240
+          portRangeMax: 4240
+          protocol: tcp
+          description: "Allow HealthCheck traffic for Cilium"
+        - remoteManagedGroups:
+          - controlplane
+          - worker
+          direction: ingress
+          etherType: IPv4
+          name: Hubble (Cilium)
+          portRangeMin: 4244
+          portRangeMax: 4244
+          protocol: tcp
+          description: "Allow Hubble traffic for Cilium"
       managedSubnets:
         - cidr: {{ .Values.node_cidr }}
           dnsNameservers:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds security rules for the Cilium into the default security groups for control-plane and worker nodes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #74 

**Special notes for your reviewer**:
This is how security groups for control-plane and worker nodes look like now:
![sec-group-contorlplane](https://github.com/SovereignCloudStack/cluster-stacks/assets/72123234/184bb23b-538f-41b8-8cec-e5f223e83076)
![sec-groups-worker](https://github.com/SovereignCloudStack/cluster-stacks/assets/72123234/db0f6081-2f9e-40e8-9961-68e3a48693e3)

