### PR TITLE
:bug: Remove unnecessary default values ​​from OpenStackClusterTemplate and OpenStackMachineTemplates

### DIFF
--- a/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
+++ b/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
@@ -6,8 +6,8 @@ spec:
   template:
     spec:
       identityRef:
-        cloudName: {{ default "openstack" .Values.identityRef.cloudName }}
-        name: {{ default "openstack" .Values.identityRef.name }}
+        cloudName: {{ .Values.identityRef.cloudName }}
+        name: {{ .Values.identityRef.name }}
       apiServerLoadBalancer:
         enabled: {{ .Values.openstack_loadbalancer_apiserver }}
 {{- if .Values.restrict_kubeapi }}

--- a/providers/openstack/scs/cluster-class/templates/openstack-machine-template-control-plane.yaml
+++ b/providers/openstack/scs/cluster-class/templates/openstack-machine-template-control-plane.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       flavor: {{ .Values.controller_flavor }}
       identityRef:
-        cloudName: {{ default "openstack" .Values.identityRef.cloudName }}
-        name: {{ default "openstack" .Values.identityRef.name }}
+        cloudName: {{ .Values.identityRef.cloudName }}
+        name: {{ .Values.identityRef.name }}
       image:
         filter:
           name: {{ .Values.images.controlPlane.name }}

--- a/providers/openstack/scs/cluster-class/templates/openstack-machine-template-worker.yaml
+++ b/providers/openstack/scs/cluster-class/templates/openstack-machine-template-worker.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       flavor: {{ .Values.worker_flavor }}
       identityRef:
-        cloudName: {{ default "openstack" .Values.identityRef.cloudName }}
-        name: {{ default "openstack" .Values.identityRef.name }}
+        cloudName: {{ .Values.identityRef.cloudName }}
+        name: {{ .Values.identityRef.name }}
       image:
         filter:
           name: {{ .Values.images.worker.name }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove unnecessary default values ​​from OpenStackClusterTemplate, which are not needed cause they are defined in the values.yaml