### PR TITLE
:sparkles: Possibility to leave external network ID empty

### DIFF
--- a/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
@@ -38,9 +38,9 @@ spec:
       schema:
         openAPIV3Schema:
           type: string
-          default: "ebfe5546-f09f-4f42-ab54-094e457d42ec"
+          default: ""
           example: "ebfe5546-f09f-4f42-ab54-094e457d42ec"
-          format: "uuid4"
+          pattern: "^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
           description: "ExternalNetworkID is the ID of an external OpenStack Network. This is necessary to get public internet to the VMs."
     - name: controller_flavor
       required: false
@@ -561,7 +561,10 @@ cre ate group names like oidc:engineering and oidc:infra."
             matchResources:
               infrastructureCluster: true
           jsonPatches:
-          - op: replace
+          - op: add
+            path: "/spec/template/spec/externalNetwork"
+            value: {}
+          - op: add
             path: "/spec/template/spec/externalNetwork/id"
             valueFrom:
               variable: external_id

--- a/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
@@ -38,9 +38,8 @@ spec:
       schema:
         openAPIV3Schema:
           type: string
-          default: ""
           example: "ebfe5546-f09f-4f42-ab54-094e457d42ec"
-          pattern: "^(|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+          format: "uuid4"
           description: "ExternalNetworkID is the ID of an external OpenStack Network. This is necessary to get public internet to the VMs."
     - name: controller_flavor
       required: false
@@ -553,7 +552,7 @@ cre ate group names like oidc:engineering and oidc:infra."
                 sizeGiB: {{"{{"}} .worker_root_disk {{"}}"}}
     - name: external_id
       description: "Sets the ID of an external OpenStack Network. This is necessary to get public internet to the VMs."
-      enabledIf: {{ `'{{ ne .external_id "" }}'` }}
+      enabledIf: {{ `"{{ if .external_id }}true{{end}}"` }}
       definitions:
         - selector:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
+++ b/providers/openstack/scs/cluster-class/templates/openstack-cluster-template.yaml
@@ -21,5 +21,3 @@ spec:
           {{- range .Values.dns_nameservers }}
             - {{ . }}
           {{- end }}
-      externalNetwork:
-        id: {{ .Values.external_id }}

--- a/providers/openstack/scs/cluster-class/values.yaml
+++ b/providers/openstack/scs/cluster-class/values.yaml
@@ -1,5 +1,4 @@
 # mirrored from variables.tf
-external_id: ebfe5546-f09f-4f42-ab54-094e457d42ec
 dns_nameservers:
   - 5.1.66.255
   - 185.150.99.255


### PR DESCRIPTION
**What this PR does / why we need it**:
As of the latest [CAPO docs](https://cluster-api-openstack.sigs.k8s.io/clusteropenstack/configuration#external-network) it's possible to leave the external network ID empty if there is only a one external network which will be picked automatically.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #100 
