### PR TITLE
:sparkles: Add network MTU variable into cluster-class

### DIFF
--- a/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs/cluster-class/templates/cluster-class.yaml
@@ -305,6 +305,13 @@ Iss uer URL )# where ( Issuer URL ) is the value of --oidc-issuer-url. The value
               description: "Prefix prepended to group claims to prevent clashes
 wit h existing names (such as system: groups). For example, the value oidc: will
 cre ate group names like oidc:engineering and oidc:infra."
+    - name: network_mtu
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: integer
+          example: 1500
+          description: "NetworkMTU sets the maximum transmission unit (MTU) value to address fragmentation for the private network ID."
   patches:
     - name: k8s_version
       description: "Sets the openstack node image for workers and the controlplane to the cluster-api image with the version mentioned in spec.topology.version."
@@ -567,6 +574,20 @@ cre ate group names like oidc:engineering and oidc:infra."
             path: "/spec/template/spec/externalNetwork/id"
             valueFrom:
               variable: external_id
+    - name: network_mtu
+      description: "Sets the network MTU when variable network_mtu exist in cluster resource."
+      enabledIf: {{ `"{{ if .network_mtu }}true{{end}}"` }}
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackClusterTemplate
+            matchResources:
+              infrastructureCluster: true
+          jsonPatches:
+          - op: add
+            path: "/spec/template/spec/networkMTU"
+            valueFrom:
+              variable: network_mtu
     - name: openstack_security_groups
       description: "Sets the list of the openstack security groups for the worker and the controlplane instances."
       enabledIf: {{ `"{{ if .openstack_security_groups }}true{{end}}"` }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an option to specify network MTU via variable in your cluster resource

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #149 

**Special notes for your reviewer**:
Tested with `cluster.yaml` file, which looks like:
```
apiVersion: cluster.x-k8s.io/v1beta1
kind: Cluster
metadata:
  name: cs-cluster
  labels:
    managed-secret: cloud-config
spec:
  clusterNetwork:
    pods:
      cidrBlocks:
        - 192.168.0.0/16
    serviceDomain: cluster.local
    services:
      cidrBlocks:
        - 10.96.0.0/12
  topology:
    variables:
      - name: controller_flavor
        value: "SCS-2V-4-50"
      - name: worker_flavor
        value: "SCS-2V-4-50"
#      - name: external_id
#        value: ebfe5546-f09f-4f42-ab54-094e457d42ec # gx-scs
      - name: network_mtu
        value: 1420
    class: openstack-scs-1-28-v0-sha.wenvkai
    controlPlane:
      replicas: 1
    version: v1.28.11
    workers:
      machineDeployments:
        - class: default-worker
          failureDomain: nova
          name: default-worker
          replicas: 3
```
After the cluster was spawned successfully, in the `gx-scs` infrastructure, we are able to see changed MTU for the cluster network
![network_mtu](https://github.com/user-attachments/assets/1d4d546b-8272-4fa5-b98f-eb93584685d6)


_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
