### PR TITLE
:book: Fix CS_K8S_PATCH_VERSION variable in quickstart guide

### DIFF
--- a/docs/providers/openstack/quickstart.md
+++ b/docs/providers/openstack/quickstart.md
@@ -176,7 +176,7 @@ export CS_POD_CIDR=192.168.0.0/16
 export CS_SERVICE_CIDR=10.96.0.0/12
 export CS_EXTERNAL_ID=ebfe5546-f09f-4f42-ab54-094e457d42ec # gx-scs
 export CS_CLASS_NAME=openstack-"${CS_NAME}"-"${CS_K8S_VERSION/./-}"-"${CS_VERSION}"
-export CS_K8S_PATCH_VERSION=8
+export CS_K8S_PATCH_VERSION=6
 ```
 
 Create and apply `cluster.yaml` file to the management cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the quickstart guide, which contains an incorrect Kubernetes patch version for the given cluster stack.

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
