### PR TITLE
:book: Tell user to avoid the distro envsubst.

### DIFF
--- a/docs/providers/openstack/quickstart.md
+++ b/docs/providers/openstack/quickstart.md
@@ -55,6 +55,7 @@ Install the [envsubst](https://github.com/drone/envsubst) Go package. It is requ
 ```bash
 GOBIN=/tmp go install github.com/drone/envsubst/v2/cmd/envsubst@latest
 ```
+Note: On typical Linux distros, you will have a binary `/usr/bin/envsubst` from the gettext package that does *not* work.
 
 Get the latest CSO release version and apply CSO manifests to the management cluster.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid the gettext envsubst trap.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #191.

**Special notes for your reviewer**:

This is the minimal fix for #191. As soon as we have something better, this can of course be superceded again.