### PR TITLE
:book: Document the CS_EXTERNAL_ID in the quickstart.

### DIFF
--- a/docs/providers/openstack/quickstart.md
+++ b/docs/providers/openstack/quickstart.md
@@ -174,10 +174,13 @@ export CS_CLUSTER_NAME=cs-cluster
 export CS_POD_CIDR=192.168.0.0/16
 # Note: if you need more than one SERVICE_CIDR, please adjust the yaml file accordingly
 export CS_SERVICE_CIDR=10.96.0.0/12
-export CS_EXTERNAL_ID=ebfe5546-f09f-4f42-ab54-094e457d42ec # gx-scs
+export CS_EXTERNAL_ID=ebfe5546-f09f-4f42-ab54-094e457d42ec # Replace this by your external network ID
 export CS_CLASS_NAME=openstack-"${CS_NAME}"-"${CS_K8S_VERSION/./-}"-"${CS_VERSION}"
 export CS_K8S_PATCH_VERSION=6
 ```
+
+The `CS_EXTERNAL_ID` must be the UUID of your OpenStack external network, get it via
+`openstack network list --external`.
 
 Create and apply `cluster.yaml` file to the management cluster.
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The CS_EXTERNAL_ID is not obvious in the quickstart guide, which can be fixed with one sentence.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #192.