### PR TITLE
Support latest k8s patches (and CSI and OCCM).

### DIFF
--- a/providers/openstack/scs/cluster-class/values.yaml
+++ b/providers/openstack/scs/cluster-class/values.yaml
@@ -1,6 +1,6 @@
 # mirrored from variables.tf
-controller_flavor: SCS-2V-4-20
-worker_flavor: SCS-2V-4-20
+controller_flavor: SCS-2V-4-20s
+worker_flavor: SCS-2V-4
 restrict_kubeapi: []
 
 # newly introduced:
@@ -9,9 +9,9 @@ openstack_loadbalancer_apiserver: false
 # TBD, currently needed:
 images:
   controlPlane:
-    name: ubuntu-capi-image-v1.29.9
+    name: ubuntu-capi-image-v1.29.14
   worker:
-    name: ubuntu-capi-image-v1.29.9
+    name: ubuntu-capi-image-v1.29.14
 identityRef:
   name: openstack
   cloudName: openstack

--- a/providers/openstack/scs/csctl.yaml
+++ b/providers/openstack/scs/csctl.yaml
@@ -1,7 +1,7 @@
 apiVersion: csctl.clusterstack.x-k8s.io/v1alpha1
 config:
   clusterStackName: scs
-  kubernetesVersion: v1.29.9
+  kubernetesVersion: v1.29.14
   provider:
     apiVersion: openstack.csctl.clusterstack.x-k8s.io/v1alpha1
     config:

--- a/providers/openstack/scs/node-images/config.yaml
+++ b/providers/openstack/scs/node-images/config.yaml
@@ -3,6 +3,6 @@ openStackNodeImages:
   - createOpts:
       container_format: bare
       disk_format: qcow2
-      name: ubuntu-capi-image-v1.29.9
+      name: ubuntu-capi-image-v1.29.14
       visibility: private
-    url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.9.qcow2
+    url: https://swift.services.a.regiocloud.tech/swift/v1/AUTH_b182637428444b9aa302bb8d5a5a418c/openstack-k8s-capi-images/ubuntu-2204-kube-v1.29/ubuntu-2204-kube-v1.29.14.qcow2

--- a/providers/openstack/scs/versions.yaml
+++ b/providers/openstack/scs/versions.yaml
@@ -1,9 +1,9 @@
-- kubernetes: 1.29.10
+- kubernetes: 1.29.14
   cinder_csi: 2.29.2
   occm: 2.29.3
-- kubernetes: 1.30.6
-  cinder_csi: 2.30.0
-  occm: 2.30.3
-- kubernetes: 1.31.2
-  cinder_csi: 2.31.2
-  occm: 2.31.1
+- kubernetes: 1.30.10
+  cinder_csi: 2.30.2
+  occm: 2.30.4
+- kubernetes: 1.31.6
+  cinder_csi: 2.31.6
+  occm: 2.31.2


### PR DESCRIPTION
**What this PR does / why we need it**:

We want users to get the latest patch versions for k8s.
We also want them to get the fixes for CSI and OCCM.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

We are outdated and not in compliance with https://docs.scs.community/standards/scs-0210-v2-k8s-version-policy

**TODOs**:

- [ ] squash commits
- [ ] add unit tests
