### PR TITLE
feat(cluster-addon): Use IPAM mode Kubernetes

### DIFF
--- a/providers/openstack/scs/cluster-addon/values.yaml
+++ b/providers/openstack/scs/cluster-addon/values.yaml
@@ -52,3 +52,6 @@ openstack-cinder-csi:
 yawol-controller:
   yawolOSSecretName: cloud-config
   enabled: false
+cilium:
+  ipam:
+    mode: "kubernetes"


### PR DESCRIPTION
Cilium doesn't use the IP settings from `Cluster.spec.clusterNetwork` because it has its own IPAM mode.
Since we currently don't need the extra features of Cilium, we'll set it to Kubernetes mode.

<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #198 

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests
