### PR TITLE
Fix/disk bus hardware

### DIFF
--- a/providers/openstack/scs/cluster-class/templates/image.yaml
+++ b/providers/openstack/scs/cluster-class/templates/image.yaml
@@ -10,8 +10,9 @@ spec:
   managementPolicy: managed
   resource:
     properties:
-      diskBus: "scsi"
-      scsiModel: "virtio-scsi"      
+      hardware:
+        diskBus: "scsi"
+        scsiModel: "virtio-scsi"      
     content:
       diskFormat: qcow2
       download:

--- a/providers/openstack/scs/cluster-class/templates/image.yaml
+++ b/providers/openstack/scs/cluster-class/templates/image.yaml
@@ -12,7 +12,17 @@ spec:
     properties:
       hardware:
         diskBus: "scsi"
-        scsiModel: "virtio-scsi"      
+        scsiModel: "virtio-scsi"
+        vifModel: virtio
+        qemuGuestAgent: true
+        rngModel: virtio
+      architecture: "x86_64"
+      minDiskGB: 20
+      minMemoryMB: 2048
+      operatingSystem:
+        distro: "ubuntu"
+        version: "22.04"
+    # hypervisorType: kvm
     content:
       diskFormat: qcow2
       download:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes #226

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #226

**Special notes for your reviewer **:
This PR consists of two commits.
The first fixes the hierarchy of the fields `diskBus` and `scsiModel` to live below `hardware`.
The second adds a few more fields from the intersection of the SCS image metadata recommendations and the fields supported by the ORC schema.