### PR TITLE
Fix/scs2 no cloud provider

### DIFF
--- a/providers/openstack/scs2/cluster-class/templates/kubeadm-control-plane-template.yaml
+++ b/providers/openstack/scs2/cluster-class/templates/kubeadm-control-plane-template.yaml
@@ -10,6 +10,7 @@ spec:
           apiServer:
           controllerManager:
             extraArgs:
+              cloud-provider: external
               bind-address: 0.0.0.0
               secure-port: "10257"
           scheduler:


### PR DESCRIPTION
kube-apiserver 1.33 does no longer tolerate `--cloud-provider`.