### PR TITLE
Feat/new releases 202602

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,3 @@ the [SCS registry](oci://registry.scs.community/kaas/cluster-stacks).
 - [Matrix](https://matrix.to/#/!NZpJdPGjAHISXnHUil:matrix.org)
 - [notes](https://input.scs.community/2025-scs-team-container)
 
-

--- a/providers/openstack/scs2/cluster-addon/ccm/Chart.yaml
+++ b/providers/openstack/scs2/cluster-addon/ccm/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
   - alias: openstack-cloud-controller-manager
     name: openstack-cloud-controller-manager
     repository: https://kubernetes.github.io/cloud-provider-openstack
-    version: 2.34.1
+    version: 2.34.2

--- a/providers/openstack/scs2/cluster-addon/csi/Chart.yaml
+++ b/providers/openstack/scs2/cluster-addon/csi/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
   - alias: openstack-cinder-csi
     name: openstack-cinder-csi
     repository: https://kubernetes.github.io/cloud-provider-openstack
-    version: 2.34.1
+    version: 2.34.3

--- a/providers/openstack/scs2/csctl.yaml
+++ b/providers/openstack/scs2/csctl.yaml
@@ -1,7 +1,7 @@
 apiVersion: csctl.clusterstack.x-k8s.io/v1alpha1
 config:
   clusterStackName: scs2
-  kubernetesVersion: v1.34.3
+  kubernetesVersion: v1.34.4
   provider:
     apiVersion: openstack.csctl.clusterstack.x-k8s.io/v1alpha1
     type: openstack

--- a/providers/openstack/scs2/kubernetes.yaml
+++ b/providers/openstack/scs2/kubernetes.yaml
@@ -25,6 +25,10 @@ images:
     tags:
       - clusterstacks
     versions:
+      - version: 'v1.32.12'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2204-kube-v1.32/ubuntu-2204-kube-v1.32.12.qcow2
+        checksum: "sha256:cb39992db553b7106c4b127cb3e9cd6418ce830d26aad2b5ab364d1dcc222fa6"
+        build_date: 2026-02-13
       - version: 'v1.33.4'
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.4.qcow2
         checksum: "sha256:1f55111551d5c9948d4e02215be56a712ed818d9000592d4f11d4b6cc4407ade"
@@ -37,6 +41,14 @@ images:
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.6.qcow2
         checksum: "sha256:ff458b22c33fc08eca9ba6635783e9a409b6f0613f577c4acdec554db7e2f6a7"
         build_date: 2025-12-17
+      - version: 'v1.33.7'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.7.qcow2
+        checksum: "sha256:ccdc2649c06f4d81ec17d823cc43a88336799b4fffce7aef42340fcb42a1b774"
+        build_date: 2025-12-17
+      - version: 'v1.33.8'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.8.qcow2
+        checksum: "sha256:203f5635447f4a59e220bfb649c40eb86f065c051650e4ea1cd11706c0d1f5be"
+        build_date: 2026-02-13
       - version: 'v1.34.0'
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.0.qcow2
         checksum: "sha256:1321c0978818752619ab994acccf4e2d9b241aa738fc56ed0a46b0ebe21fedfb"
@@ -53,3 +65,11 @@ images:
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.3.qcow2
         checksum: "sha256:b3c487345dd8ff2eea6ddd3e526d068abc3a59d40a994581f6dfc7be10df427b"
         build_date: 2025-12-17
+      - version: 'v1.34.4'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.4.qcow2
+        checksum: "sha256:df3f26b0026a1a9ca3b681df2d8675a7341e138dca6f2326592975bb7c0fe792"
+        build_date: 2026-02-13
+      - version: 'v1.35.1'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.35/ubuntu-2404-kube-v1.35.1.qcow2
+        checksum: "sha256:5d424380e2fa85b7a51ad1e955e8efb09ca460b0e80d47cf2f36c02d94dc3f03"
+        build_date: 2026-02-13

--- a/providers/openstack/scs2/versions.yaml
+++ b/providers/openstack/scs2/versions.yaml
@@ -1,9 +1,12 @@
-- kubernetes: 1.32.8
+- kubernetes: 1.32.12
   cinder_csi: 2.32.2
-  occm: 2.32.0
-- kubernetes: 1.33.7
+  occm: 2.32.1
+- kubernetes: 1.33.8
   cinder_csi: 2.33.1
   occm: 2.33.1
-- kubernetes: 1.34.3
-  cinder_csi: 2.34.1
-  occm: 2.34.1
+- kubernetes: 1.34.4
+  cinder_csi: 2.34.3
+  occm: 2.34.2
+- kubernetes: 1.35.1
+  cinder_csi: 2.35.0
+  occm: 2.35.0


### PR DESCRIPTION
Update to latest k8s versions:
* v1.32.12 (w/ CSI 2.32.2 and OCCM 2.32.1)
* v1.33.8  (w/ CSI 2.33.1 and OCCM 2.33.1)
* v1.34.4  (w/ CSI 2.34.3 and OCCM 2.34.2)
* v1.35.1  (w/ CSI 2.35.0 and OCCM 2.35.0)
    
Add images info for 1.32.12, 1.33.7, 1.33.8, 1.34.4, 1.35.1.

Push csctl versions to publish k8s/ccsi/occm 1.34.4/2.34.3/2.34.2.

Pushed to registry for testing as `openstack-scs2-1-34-v0-git-98555b0`.
Will use branches to push 1-33 and 1-35.