### PR TITLE
Feat/update k8s 20260417 1 33

### DIFF
--- a/providers/openstack/scs2/cluster-addon/ccm/Chart.yaml
+++ b/providers/openstack/scs2/cluster-addon/ccm/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
   - alias: openstack-cloud-controller-manager
     name: openstack-cloud-controller-manager
     repository: https://kubernetes.github.io/cloud-provider-openstack
-    version: 2.34.1
+    version: 2.33.1

--- a/providers/openstack/scs2/cluster-addon/cni/Chart.yaml
+++ b/providers/openstack/scs2/cluster-addon/cni/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
   - alias: cilium
     name: cilium
     repository: https://helm.cilium.io/
-    version: 1.18.5
+    version: 1.18.9

--- a/providers/openstack/scs2/cluster-addon/csi/Chart.yaml
+++ b/providers/openstack/scs2/cluster-addon/csi/Chart.yaml
@@ -7,4 +7,4 @@ dependencies:
   - alias: openstack-cinder-csi
     name: openstack-cinder-csi
     repository: https://kubernetes.github.io/cloud-provider-openstack
-    version: 2.34.1
+    version: 2.33.1

--- a/providers/openstack/scs2/cluster-class/Chart.yaml
+++ b/providers/openstack/scs2/cluster-class/Chart.yaml
@@ -4,6 +4,6 @@ description: "This chart installs and configures:
   * Openstack scs2 Cluster Class
 
   "
-name: openstack-scs2-1-34-cluster-class
+name: openstack-scs2-1-33-cluster-class
 type: application
 version: v1

--- a/providers/openstack/scs2/csctl.yaml
+++ b/providers/openstack/scs2/csctl.yaml
@@ -1,7 +1,7 @@
 apiVersion: csctl.clusterstack.x-k8s.io/v1alpha1
 config:
   clusterStackName: scs2
-  kubernetesVersion: v1.34.3
+  kubernetesVersion: v1.33.10
   provider:
     apiVersion: openstack.csctl.clusterstack.x-k8s.io/v1alpha1
     type: openstack

--- a/providers/openstack/scs2/image.yaml
+++ b/providers/openstack/scs2/image.yaml
@@ -2,7 +2,7 @@
 apiVersion: openstack.k-orc.cloud/v1alpha1
 kind: Image
 metadata:
-  name: "ubuntu-capi-image-v1.33.6"
+  name: "ubuntu-capi-image-v1.33.10"
 spec:
   cloudCredentialsRef:
     cloudName: "openstack"
@@ -26,7 +26,7 @@ spec:
     content:
       diskFormat: qcow2
       download:
-        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.6.qcow2
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.10.qcow2
         hash:
           algorithm: sha256
-          value: ff458b22c33fc08eca9ba6635783e9a409b6f0613f577c4acdec554db7e2f6a7
+          value: efc3817b565c407710724b9d7b51cbb433638aad6b613b64843da28d58a777aa

--- a/providers/openstack/scs2/kubernetes.yaml
+++ b/providers/openstack/scs2/kubernetes.yaml
@@ -37,6 +37,22 @@ images:
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.6.qcow2
         checksum: "sha256:ff458b22c33fc08eca9ba6635783e9a409b6f0613f577c4acdec554db7e2f6a7"
         build_date: 2025-12-17
+      - version: 'v1.33.7'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.7.qcow2
+        checksum: "sha256:ccdc2649c06f4d81ec17d823cc43a88336799b4fffce7aef42340fcb42a1b774"
+        build_date: 2025-12-17
+      - version: 'v1.33.8'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.8.qcow2
+        checksum: "sha256:203f5635447f4a59e220bfb649c40eb86f065c051650e4ea1cd11706c0d1f5be"
+        build_date: 2026-02-11
+      - version: 'v1.33.9'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.9.qcow2
+        checksum: "sha256:5eec6526242f1b3a35b4ac2449a42a8e13b2279724669b87f1dce28dbd05f234"
+        build_date: 2026-02-28
+      - version: 'v1.33.10'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.33/ubuntu-2404-kube-v1.33.10.qcow2
+        checksum: "sha256:efc3817b565c407710724b9d7b51cbb433638aad6b613b64843da28d58a777aa"
+        build_date: 2026-03-20
       - version: 'v1.34.0'
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.0.qcow2
         checksum: "sha256:1321c0978818752619ab994acccf4e2d9b241aa738fc56ed0a46b0ebe21fedfb"
@@ -53,3 +69,19 @@ images:
         url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.3.qcow2
         checksum: "sha256:b3c487345dd8ff2eea6ddd3e526d068abc3a59d40a994581f6dfc7be10df427b"
         build_date: 2025-12-17
+      - version: 'v1.34.4'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.4.qcow2
+        checksum: "sha256:df3f26b0026a1a9ca3b681df2d8675a7341e138dca6f2326592975bb7c0fe792"
+        build_date: 2026-02-11
+      - version: 'v1.34.5'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.5.qcow2
+        checksum: "sha256:8d0c9308a481698d1b12f2a8b13d8fb0da8275d689bf560eeb9442de93f60d8d"
+        build_date: 2026-02-28
+      - version: 'v1.34.6'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.6.qcow2
+        checksum: "sha256:c59fb893be8320d7112473290358320fad2756e3e31dce4f90ae8bda9d289a3d"
+        build_date: 2026-03-20
+      - version: 'v1.34.7'
+        url: https://nbg1.your-objectstorage.com/osism/openstack-k8s-capi-images/ubuntu-2404-kube-v1.34/ubuntu-2404-kube-v1.34.7.qcow2
+        checksum: "sha256:f7bf12297833cca14de6d24081c8a01e99143651e4c01431b911375300550fe0"
+        build_date: 2026-04-16

--- a/providers/openstack/scs2/versions.yaml
+++ b/providers/openstack/scs2/versions.yaml
@@ -1,9 +1,9 @@
-- kubernetes: 1.32.8
+- kubernetes: 1.32.13
   cinder_csi: 2.32.2
-  occm: 2.32.0
-- kubernetes: 1.33.7
+  occm: 2.32.1
+- kubernetes: 1.33.10
   cinder_csi: 2.33.1
   occm: 2.33.1
-- kubernetes: 1.34.3
-  cinder_csi: 2.34.1
-  occm: 2.34.1
+- kubernetes: 1.34.7
+  cinder_csi: 2.34.3
+  occm: 2.34.2


### PR DESCRIPTION
This is for updating 1.33 to 1.33.10.
No OCCM / Cinder-CSI upgrades.
Cilium goes from 1.8.5 to 1.18.9.

Reference: https://input.scs.community/sP49NVfCShScjmC1iceSqA#

Published to our registry: https://registry.scs.community/harbor/projects/41/repositories/cluster-stacks/artifacts-tab/artifacts/sha256:dce929e265af6bead788eb65c8dba7c1510474e4266fccfb761596e6ed003741?sbomDigest=
`openstack-scs2-1-33-v0-git-6aff802`

Test status:
- Rolling upgrade from v4 (1.33.7) to v0-git.6aff802 (1.33.10) succeeded.
- e2e tests currently running

Note: 1.33.11 was released a few days ago.
Probably we should wait for the node image to appear and upgrade to it directly.