### PR TITLE
Add optional availabilityZone.from:Machine to disks.

### DIFF
--- a/providers/openstack/scs2/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs2/cluster-class/templates/cluster-class.yaml
@@ -133,6 +133,19 @@ spec:
             Root disk size in GiB for control-plane nodes.
             OpenStack volume will be created and used instead of an ephemeral disk defined in flavor.
             Should only be used for the diskless flavors (>= 20), otherwise set to 0.
+    - name: controlPlaneRootDiskPin
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
+          example: true
+          default: false
+          description: |-
+            Pass availabilityZone (failureDomain) of the worker machine to the root disk.
+            Some clouds have a 1:1 relationship of storage availability zones with compute AZs.
+            In these, attaching a disk from another AZ often comes with a performance penalty
+            or is not possible at all. You want to set to true to tell capo to create the root
+            disk in the stated failureDomain of this machine deployment.
     - name: controlPlaneServerGroupID
       required: false
       schema:
@@ -180,6 +193,19 @@ spec:
             Root disk size in GiB for worker nodes.
             OpenStack volume will be created and used instead of an ephemeral disk defined in flavor.
             Should be used for the diskless flavors (>= 20), otherwise set to 0.
+    - name: workerRootDiskPin
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
+          example: true
+          default: false
+          description: |-
+            Pass availabilityZone (failureDomain) of the machine to the root disk.
+            Some clouds have a 1:1 relationship of storage availability zones with compute AZs.
+            In these, attaching a disk from another AZ often comes with a performance penalty
+            or is not possible at all. You want to set to true to tell capo to create the root
+            disk in the wanted AZ of the machine.
     - name: workerServerGroupID
       required: false
       schema:
@@ -193,6 +219,9 @@ spec:
       schema:
         openAPIV3Schema:
           type: array
+          description: |-
+            You may pass an array with additional volumes (disks) here, consisting of
+            name, sizeGiB (default: 20) and type (aka storage class, default: __DEFAULT__).
           default: []
           items:
             type: object
@@ -206,6 +235,19 @@ spec:
                 type: string
                 default: "__DEFAULT__"
           required: ["name"]
+    - name: workerAdditionalBlockDevicesPin
+      required: false
+      schema:
+        openAPIV3Schema:
+          type: boolean
+          example: true
+          default: false
+          description: |-
+            Pass availabilityZone (failureDomain) of the machine to the additional disks.
+            Some clouds have a 1:1 relationship of storage availability zones with compute AZs.
+            In these, attaching a disk from another AZ often comes with a performance penalty
+            or is not possible at all. You want to set to true to tell capo to create the
+            additional disks in the wanted AZ of the machine.
     # Access management
     - name: sshKeyName
       required: false
@@ -570,7 +612,7 @@ spec:
                 variable: controlPlaneFlavor
     - name: controlPlaneRootDisk
       description: "Sets the root disk size in GiB for control-plane nodes."
-      enabledIf: {{ `'{{ if .controlPlaneRootDisk }}true{{end}}'` }}
+      enabledIf: {{ `'{{ if and .controlPlaneRootDisk (not .controlPlaneRootDiskPin) }}true{{end}}'` }}
       definitions:
         - selector:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -583,6 +625,23 @@ spec:
               valueFrom:
                 template: |
                   sizeGiB: {{ `{{ .controlPlaneRootDisk }}` }}
+    - name: controlPlaneRootDiskPinned
+      description: "Sets the root disk size in GiB for control-plane nodes and pins them to the failureDomain of the machine."
+      enabledIf: {{ `'{{ if and .controlPlaneRootDisk .controlPlaneRootDiskPin }}true{{end}}'` }}
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            matchResources:
+              controlPlane: true
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/rootVolume"
+              valueFrom:
+                template: |
+                  sizeGiB: {{ `{{ .controlPlaneRootDisk }}` }}
+                  availabilityZone:
+                    from: Machine
     - name: controlPlaneServerGroupID
       description: "Sets the server group to assign the control plane nodes to."
       enabledIf: {{ `'{{ ne .controlPlaneServerGroupID "" }}'` }}
@@ -697,7 +756,7 @@ spec:
                 variable: workerFlavor
     - name: workerRootDisk
       description: "Sets the root disk size in GiB for worker nodes."
-      enabledIf: {{ `'{{ if .workerRootDisk }}true{{end}}'` }}
+      enabledIf: {{ `'{{ if and .workerRootDisk (not .workerRootDiskPin) }}true{{end}}'` }}
       definitions:
         - selector:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -713,6 +772,26 @@ spec:
               valueFrom:
                 template: |
                   sizeGiB: {{ `{{ .workerRootDisk }}` }}
+    - name: workerRootDiskPinned
+      description: "Sets the root disk size in GiB for worker nodes and pins the to the AZ of the machine."
+      enabledIf: {{ `'{{ if and .workerRootDisk .workerRootDiskPin }}true{{end}}'` }}
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            matchResources:
+              controlPlane: false
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: "/spec/template/spec/rootVolume"
+              valueFrom:
+                template: |
+                  sizeGiB: {{ `{{ .workerRootDisk }}` }}
+                  availabilityZone:
+                    from: Machine
     - name: workerServerGroupID
       description: "Sets the server group to assign the worker nodes to."
       enabledIf: {{ `'{{ ne .workerServerGroupID "" }}'` }}
@@ -732,7 +811,7 @@ spec:
                 template: |
                   id: {{ `{{ .workerServerGroupID }}` }}
     - name: workerAdditionalBlockDevices
-      enabledIf: {{ `'{{ if .workerAdditionalBlockDevices }}true{{end}}'` }}
+      enabledIf: {{ `'{{ if and .workerAdditionalBlockDevices (not .workerAdditionalBlockDevicesPin) }}true{{end}}'` }}
       definitions:
         - selector:
             apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -750,6 +829,32 @@ spec:
                   {{ `{{- range .workerAdditionalBlockDevices }}` }}
                   - name: {{ `{{ .name }}` }}
                     sizeGiB: {{ `{{ .sizeGiB }}` }}
+                    storage:
+                      type: Volume
+                      volume:
+                        type: {{ `{{ .type }}` }}
+                  {{ `{{- end }}` }}
+    - name: workerAdditionalBlockDevicesPinned
+      enabledIf: {{ `'{{ if and .workerAdditionalBlockDevices .workerAdditionalBlockDevicesPin }}true{{end}}'` }}
+      definitions:
+        - selector:
+            apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+            kind: OpenStackMachineTemplate
+            matchResources:
+              controlPlane: false
+              machineDeploymentClass:
+                names:
+                  - default-worker
+          jsonPatches:
+            - op: add
+              path: /spec/template/spec/additionalBlockDevices
+              valueFrom:
+                template: |
+                  {{ `{{- range .workerAdditionalBlockDevices }}` }}
+                  - name: {{ `{{ .name }}` }}
+                    sizeGiB: {{ `{{ .sizeGiB }}` }}
+                    availabilityZone:
+                      from: Machine
                     storage:
                       type: Volume
                       volume:


### PR DESCRIPTION
Previously capo defaulted to creating disks in the failureDomain (availability zone) of the virtual machine that is created. In some clouds this is a requirement for good performance or to be able to attach the disk at all.
Other clouds have a global AZ for disks, so we need a pararmeter to control this.

So we introduce three new boolean variables, all defaulting to false: controlPlaneRootDiskPin
workerRootDiskPin
workerAdditionalBlockDevicesPin
which control whether we set
availabilityZone/from: Machine for the respective disks.

Needs testing!