### PR TITLE
Fix cluster-class naming to be 1-34.

### DIFF
--- a/providers/openstack/scs2/cluster-class/Chart.yaml
+++ b/providers/openstack/scs2/cluster-class/Chart.yaml
@@ -4,6 +4,6 @@ description: "This chart installs and configures:
   * Openstack scs2 Cluster Class
 
   "
-name: openstack-scs2-1-33-cluster-class
+name: openstack-scs2-1-34-cluster-class
 type: application
 version: v1


### PR DESCRIPTION
As reported from @schmidax:
I apparently overlooked to check-in one change of cluster class where 1-33 was remaining and 1-34 should have been ...