### PR TITLE
Improved wording suggesting SCS-2V-4-20s for control plane.

### DIFF
--- a/providers/openstack/scs2/cluster-class/templates/cluster-class.yaml
+++ b/providers/openstack/scs2/cluster-class/templates/cluster-class.yaml
@@ -120,7 +120,7 @@ spec:
           example: "SCS-2V-4-20s"
           description: |-
             OpenStack instance flavor for control plane nodes.
-            (Default: SCS-2V-4, replace by SCS-2V-4-20s or specify a controlPlaneRootDisk.)
+            (Default: SCS-2V-4, specify a controlPlanRootDisk or better replace by SCS-2V-4-20s.)
     - name: controlPlaneRootDisk
       required: false
       schema:


### PR DESCRIPTION
The real reason for this change is to be able to publish something new.

See https://github.com/SovereignCloudStack/cluster-stacks/pull/264#issuecomment-4369260548